### PR TITLE
Build.md: do not instruct to compile as root and fix build command

### DIFF
--- a/build.md
+++ b/build.md
@@ -143,7 +143,7 @@ cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain-linux-i686.cmake -DCMAKE_BUILD_T
 And finally we can build and install the application. The installation step may require administrative privileges to install software under `/usr/local`.
 
 ```
-sudo cmake --build . --parallel --target install
+make --jobs $(nproc) && sudo make install
 ```
 
 After the installation process is complete the game can be started with the `max-port` command from the terminal window, or with the `M.A.X. Port` desktop icon from the Apps menu. To configure and actually run the game please read relevant sections of the [Installation Guideline](install.md).
@@ -208,7 +208,7 @@ cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain-linux-x86_64.cmake -DCMAKE_BUILD
 And finally we can build and install the application. The installation step may require administrative privileges to install software under `/usr/local`.
 
 ```
-sudo cmake --build . --parallel --target install
+make --jobs $(nproc) && sudo make install
 ```
 
 After the installation process is complete the game can be started with the `max-port` command from the terminal window, or with the `M.A.X. Port` desktop icon from the Apps menu. To configure and actually run the game please read relevant sections of the [Installation Guideline](install.md).


### PR DESCRIPTION
Building as root his is bad practice and may even lead to security issues I also fixed the build command to work properly on my system