### PR TITLE
Xenhat/build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ if(UNIX)
 				"^libSDL2.*$"
 				"^libfreetype.*$"
 				"^libminiupnpc.*$"
+				"^libnlohmann_json_schema_validator.*$"
 		)
 
 		if(DEPS_CONFLICTING_FILENAMES)

--- a/src/ticktimer.hpp
+++ b/src/ticktimer.hpp
@@ -22,7 +22,9 @@
 #ifndef TICKTIMER_HPP
 #define TICKTIMER_HPP
 
+#if __cplusplus < 201703L
 #include <cstdbool>
+#endif
 #include <cstdint>
 
 [[nodiscard]] bool TickTimer_HaveTimeToThink() noexcept;

--- a/src/ticktimer.hpp
+++ b/src/ticktimer.hpp
@@ -22,9 +22,6 @@
 #ifndef TICKTIMER_HPP
 #define TICKTIMER_HPP
 
-#if __cplusplus < 201703L
-#include <cstdbool>
-#endif
 #include <cstdint>
 
 [[nodiscard]] bool TickTimer_HaveTimeToThink() noexcept;


### PR DESCRIPTION
Some various fixes I ended up doing to unrelated parts of the code while investigating UB and overflows:
- Fix the JSON schema validator not being packaged when using local builds
- Fix warning for deprecated cstdbool for C++17 and above